### PR TITLE
Style download resume button to match theme

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -160,14 +160,14 @@ body {
 }
 
 .btn-primary {
-    background: var(--gradient-primary);
+    background: transparent;
     color: var(--text-primary);
-    box-shadow: var(--shadow-neon);
+    border: 2px solid var(--primary-color);
 }
 
 .btn-primary:hover {
+    background: var(--primary-color);
     transform: translateY(-2px);
-    box-shadow: 0 0 30px rgba(0, 212, 255, 0.5);
 }
 
 .btn-secondary {
@@ -182,14 +182,14 @@ body {
 }
 
 .btn-download {
-    background: var(--gradient-primary);
+    background: transparent;
     color: var(--text-primary);
-    box-shadow: var(--shadow-neon);
+    border: 2px solid var(--primary-color);
 }
 
 .btn-download:hover {
+    background: var(--primary-color);
     transform: translateY(-2px);
-    box-shadow: 0 0 30px rgba(0, 212, 255, 0.5);
 }
 
 .btn-download i {

--- a/styles.css
+++ b/styles.css
@@ -182,15 +182,14 @@ body {
 }
 
 .btn-download {
-    background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
+    background: var(--gradient-primary);
     color: var(--text-primary);
-    box-shadow: 0 4px 15px rgba(102, 126, 234, 0.3);
+    box-shadow: var(--shadow-neon);
 }
 
 .btn-download:hover {
-    background: linear-gradient(135deg, #764ba2 0%, #667eea 100%);
     transform: translateY(-2px);
-    box-shadow: 0 6px 20px rgba(102, 126, 234, 0.4);
+    box-shadow: 0 0 30px rgba(0, 212, 255, 0.5);
 }
 
 .btn-download i {


### PR DESCRIPTION
Update download resume button styling to match the site's primary theme.

---
<a href="https://cursor.com/background-agent?bcId=bc-0556f5ea-bcb6-42c7-863f-4775cbfa6c92">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-0556f5ea-bcb6-42c7-863f-4775cbfa6c92">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>